### PR TITLE
Change payment to incomplete

### DIFF
--- a/code/ChequeGateway.php
+++ b/code/ChequeGateway.php
@@ -24,7 +24,7 @@ class ChequeGateway extends PaymentGateway_MerchantHosted {
   }
   
   public function process($data) {
-    return new PaymentGateway_Success();
+    return new PaymentGateway_Incomplete();
   }
 
   public function getSupportedCurrencies() {


### PR DESCRIPTION
When paying by cheque, I think process should be "incomplete" until the admin actually receives payment. At which time the site admin updates the status to complete.
